### PR TITLE
champion cards with curated content rather than from a feed

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -214,20 +214,20 @@ main .cards.overlay > ul > li p.button-container a {
   }
 }
 
-/* champions */
-main .cards.champions h3 {
+/* two-column layout; fka champions */
+main .cards.two-cols h3 {
   margin: 0;
 }
 
 @media (min-width: 900px) {
-  main .cards.champions > ul {
+  main .cards.two-cols > ul {
     grid-template-columns: repeat(auto-fill, minmax(calc((100% / 2) - 30px), 1fr));
     grid-gap: 30px;
   }
 }
 
 @media (min-width: 700px) {
-  main .cards.champions > ul > li img {
+  main .cards.two-cols > ul > li img {
     height: 355px;
   }
 }

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -30,12 +30,6 @@ main .cards .cards-card-links {
   background-color: var(--color-white);
 }
 
-main .cards.cards-champions .cards-card-body {
-  display: grid;
-  grid-template-columns: 2fr 1fr;
-  justify-content: space-between;
-}
-
 main .cards h2 {
   font-size: var(--body-font-size-xl);
   text-transform: uppercase;
@@ -59,13 +53,34 @@ main .cards .cards-card-body > *:first-child {
   margin-top: 0;
 }
 
+main .cards .cards-card-country {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: .5em 0;
+  font-size: var(--body-font-size-xs);
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+main .cards .cards-card-country .icon {
+  margin-right: 8px;
+}
+
+main .cards .cards-card-country svg {
+  width: 24px;
+}
+
+main .cards .cards-card-bubble-wrapper {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+}
+
 main .cards .cards-card-bubble {
   display: flex;
   align-items: center;
   justify-content: center;
-  position: absolute;
-  top: 16px;
-  left: 16px;
   width: 40px;
   min-height: 40px;
   border-radius: 20px;
@@ -75,24 +90,28 @@ main .cards .cards-card-bubble {
   text-decoration: none;
 }
 
-
-main .cards .cards-card-country {
-  margin: .5em 0;
-}
-
-main .cards .cards-card-country span {
-  display: inline-block;  
-  width: 24px;
-  height: 10px;
-  margin-right: 4px;
-}
-
 @media (min-width: 700px) {
   main .cards .cards-card-bubble {
     min-width: 80px;
     min-height: 80px;
     border-radius: 40px;
     font-size: var(--body-font-size-l);
+  }
+
+  main .cards .cards-card-country-wrapper {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 0 16px;
+  }
+
+  main .cards .cards-card-country-wrapper h3 {
+    flex: 1 0 auto;
+  }
+
+  main .cards .cards-card-country {
+    font-size: unset;
+    justify-self: flex-end;
   }
 }
 
@@ -196,19 +215,19 @@ main .cards.overlay > ul > li p.button-container a {
 }
 
 /* champions */
-main .cards.cards-champions h3 {
+main .cards.champions h3 {
   margin: 0;
 }
 
 @media (min-width: 900px) {
-  main .cards.cards-champions > ul {
+  main .cards.champions > ul {
     grid-template-columns: repeat(auto-fill, minmax(calc((100% / 2) - 30px), 1fr));
     grid-gap: 30px;
   }
 }
 
 @media (min-width: 700px) {
-  main .cards.cards-champions > ul > li img {
+  main .cards.champions > ul > li img {
     height: 355px;
   }
 }

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -1,3 +1,7 @@
+main .cards {
+  --card-bubble-color: var(--color-tan);
+}
+
 main .cards > ul {
   list-style: none;
   display: grid;
@@ -24,6 +28,12 @@ main .cards .cards-card-body,
 main .cards .cards-card-links {
   padding: 16px;
   background-color: var(--color-white);
+}
+
+main .cards.cards-champions .cards-card-body {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  justify-content: space-between;
 }
 
 main .cards h2 {
@@ -59,10 +69,22 @@ main .cards .cards-card-bubble {
   width: 40px;
   min-height: 40px;
   border-radius: 20px;
-  background-color: var(--color-tan);
+  background-color: var(--card-bubble-color);
   color: var(--color-white);
   font-size: var(--body-font-size-xxs);
   text-decoration: none;
+}
+
+
+main .cards .cards-card-country {
+  margin: .5em 0;
+}
+
+main .cards .cards-card-country span {
+  display: inline-block;  
+  width: 24px;
+  height: 10px;
+  margin-right: 4px;
 }
 
 @media (min-width: 700px) {

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -1,14 +1,5 @@
 import { createOptimizedPicture, readBlockConfig, lookupPages } from '../../scripts/scripts.js';
 
-// function decorateChampionCards(block) {
-//   [...block.children].forEach((row) => {
-//     const children = row.querySelectorAll('div');
-//     const pars = children[1].querySelectorAll('p');
-//     pars[0].classList.add('cards-card-bubble');
-//     pars[1].classList.add('cards-card-country');
-//   });
-// }
-
 function decorateChampionCardsFeed(champions, block) {
   block.classList.add('champions');
   // eslint-disable-next-line no-param-reassign

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -1,16 +1,16 @@
 import { createOptimizedPicture, readBlockConfig, lookupPages } from '../../scripts/scripts.js';
 
-function decorateChampionCards(block) {
-  [...block.children].forEach((row) => {
-    const children = row.querySelectorAll('div');
-    const pars = children[1].querySelectorAll('p');
-    pars[0].classList.add('cards-card-bubble');
-    pars[1].classList.add('cards-card-country');
-  });
-}
+// function decorateChampionCards(block) {
+//   [...block.children].forEach((row) => {
+//     const children = row.querySelectorAll('div');
+//     const pars = children[1].querySelectorAll('p');
+//     pars[0].classList.add('cards-card-bubble');
+//     pars[1].classList.add('cards-card-country');
+//   });
+// }
 
 function decorateChampionCardsFeed(champions, block) {
-  block.classList.add('cards-champions');
+  block.classList.add('champions');
   // eslint-disable-next-line no-param-reassign
   champions = champions.sort((a, b) => {
     const aYear = parseInt(a.title.split(' ').pop(), 10);
@@ -39,9 +39,6 @@ export default async function decorate(block) {
       const type = config.type.toLowerCase();
       if (type === 'champions') decorateChampionCardsFeed(items, block);
     }
-  } else if (block.classList.contains('cards-champions')) {
-    // champion cards with manually curated content
-    decorateChampionCards(block);
   }
 
   /* change to ul, li */
@@ -56,6 +53,12 @@ export default async function decorate(block) {
         const bubble = div.querySelector('u');
         if (bubble) {
           bubble.className = 'cards-card-bubble';
+          bubble.closest('p').className = 'cards-card-bubble-wrapper';
+        }
+        const country = div.querySelector('.icon[class*=icon-flag-]');
+        if (country) {
+          country.closest('p').classList.add('cards-card-country');
+          div.classList.add('cards-card-country-wrapper');
         }
         const list = div.querySelector('ul, ol');
         if (list) {

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -1,6 +1,15 @@
 import { createOptimizedPicture, readBlockConfig, lookupPages } from '../../scripts/scripts.js';
 
-function decorateChampionCards(champions, block) {
+function decorateChampionCards(block) {
+  [...block.children].forEach((row) => {
+    const children = row.querySelectorAll('div');
+    const pars = children[1].querySelectorAll('p');
+    pars[0].classList.add('cards-card-bubble');
+    pars[1].classList.add('cards-card-country');
+  });
+}
+
+function decorateChampionCardsFeed(champions, block) {
   block.classList.add('cards-champions');
   // eslint-disable-next-line no-param-reassign
   champions = champions.sort((a, b) => {
@@ -28,9 +37,13 @@ export default async function decorate(block) {
     const items = pages.filter((e) => e.path.startsWith(config.source));
     if (items) {
       const type = config.type.toLowerCase();
-      if (type === 'champions') decorateChampionCards(items, block);
+      if (type === 'champions') decorateChampionCardsFeed(items, block);
     }
+  } else if (block.classList.contains('cards-champions')) {
+    // champion cards with manually curated content
+    decorateChampionCards(block);
   }
+
   /* change to ul, li */
   const ul = document.createElement('ul');
   [...block.children].forEach((row) => {

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -1,7 +1,7 @@
 import { createOptimizedPicture, readBlockConfig, lookupPages } from '../../scripts/scripts.js';
 
 function decorateChampionCardsFeed(champions, block) {
-  block.classList.add('champions');
+  block.classList.add('two-cols');
   // eslint-disable-next-line no-param-reassign
   champions = champions.sort((a, b) => {
     const aYear = parseInt(a.title.split(' ').pop(), 10);

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -15,7 +15,7 @@ function decorateChampionCardsFeed(champions, block) {
     card.innerHTML = `<div>
         <a href="${champion.path}">${createOptimizedPicture(champion.image).outerHTML}</a>
       </div>
-      <div>${year ? `<p class="cards-card-bubble">${year}</p>` : ''}<h3><a href="${champion.path}">${name}</a></h3></div>`;
+      <div>${year ? `<p class="cards-card-bubble-wrapper"><u class="cards-card-bubble">${year}</u></p>` : ''}<h3><a href="${champion.path}">${name}</a></h3></div>`;
     block.append(card);
   });
 }


### PR DESCRIPTION
Allow champion cards to accept curated content.

Test URLs:
- Before: https://main--theplayers--hlxsites.hlx.live/past-champions
- After: https://champion-cards-curated--theplayers--hlxsites.hlx.live/past-champions
- After: https://champion-cards-curated--theplayers--hlxsites.hlx.page/drafts/fkakatie/sentry-past-champions
- After: https://champion-cards-curated--theplayers--hlxsites.hlx.page/drafts/fkakatie/wgc-past-champions
