### PR TITLE
feat: provide flexibility in course carousel when not driven from the stats feed

### DIFF
--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -16,9 +16,6 @@ main .carousel-container {
 main .carousel-wrapper {
   position: relative;
   max-width: 1400px;
-}
-
-main .carousel-wrapper {
   min-height: 420px;
 }
 

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -282,18 +282,30 @@ main .carousel.course > div {
 }
 
 @media (min-width: 700px) {
+  main .carousel-wrapper {
+    min-height: 670px;
+  }
+
   main .carousel.course > div {
     height: 670px;
   }
 }
 
 @media (min-width: 900px) {
+  main .carousel-wrapper {
+    min-height: 505px;
+  }
+
   main .carousel.course > div {
     height: 505px;
   }
 }
 
 @media (min-width: 1200px) {
+  main .carousel-wrapper {
+    min-height: 740px;
+  }
+
   main .carousel.course > div {
     height: 740px;
   }

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -16,6 +16,7 @@ main .carousel-container {
 main .carousel-wrapper {
   position: relative;
   max-width: 1400px;
+  min-height: 850px;
 }
 
 main .carousel {

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -405,7 +405,7 @@ main .carousel.course div.course-text h3 {
     align-self: center;
   }
 
-  main .carousel.course div.course-text .course-overview h3 {
+  main .carousel.course div.course-text .course-overview .course-heading-wrapper {
     grid-area: overview-subtitle;
   }
 

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -18,7 +18,11 @@ main .carousel-wrapper {
   max-width: 1400px;
 }
 
-main .carousel-wrapper .carousel.course {
+main .carousel-wrapper {
+  min-height: 420px;
+}
+
+main .carousel-wrapper:has(.carousel.course) {
   min-height: 850px;
 }
 
@@ -285,7 +289,11 @@ main .carousel.course > div {
 }
 
 @media (min-width: 700px) {
-  main .carousel-wrapper .carousel.course {
+  main .carousel-wrapper {
+    min-height: 670px;
+  }
+
+  main .carousel-wrapper:has(.carousel.course) {
     min-height: 670px;
   }
 
@@ -295,7 +303,11 @@ main .carousel.course > div {
 }
 
 @media (min-width: 900px) {
-  main .carousel-wrapper .carousel.course {
+  main .carousel-wrapper {
+    min-height: 505px;
+  }
+
+  main .carousel-wrapper:has(.carousel.course) {
     min-height: 505px;
   }
 
@@ -305,7 +317,11 @@ main .carousel.course > div {
 }
 
 @media (min-width: 1200px) {
-  main .carousel-wrapper .carousel.course {
+  main .carousel-wrapper {
+    min-height: 700px;
+  }
+
+  main .carousel-wrapper:has(.carousel.course) {
     min-height: 740px;
   }
 

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -16,6 +16,9 @@ main .carousel-container {
 main .carousel-wrapper {
   position: relative;
   max-width: 1400px;
+}
+
+main .carousel-wrapper:has(.carousel.course > div) {
   min-height: 850px;
 }
 
@@ -282,7 +285,7 @@ main .carousel.course > div {
 }
 
 @media (min-width: 700px) {
-  main .carousel-wrapper {
+  main .carousel-wrapper:has(.carousel.course > div) {
     min-height: 670px;
   }
 
@@ -292,7 +295,7 @@ main .carousel.course > div {
 }
 
 @media (min-width: 900px) {
-  main .carousel-wrapper {
+  main .carousel-wrapper:has(.carousel.course > div) {
     min-height: 505px;
   }
 
@@ -302,7 +305,7 @@ main .carousel.course > div {
 }
 
 @media (min-width: 1200px) {
-  main .carousel-wrapper {
+  main .carousel-wrapper:has(.carousel.course > div) {
     min-height: 740px;
   }
 

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -18,7 +18,7 @@ main .carousel-wrapper {
   max-width: 1400px;
 }
 
-main .carousel-wrapper:has(.carousel.course > div) {
+main .carousel-wrapper .carousel.course {
   min-height: 850px;
 }
 
@@ -285,7 +285,7 @@ main .carousel.course > div {
 }
 
 @media (min-width: 700px) {
-  main .carousel-wrapper:has(.carousel.course > div) {
+  main .carousel-wrapper .carousel.course {
     min-height: 670px;
   }
 
@@ -295,7 +295,7 @@ main .carousel.course > div {
 }
 
 @media (min-width: 900px) {
-  main .carousel-wrapper:has(.carousel.course > div) {
+  main .carousel-wrapper .carousel.course {
     min-height: 505px;
   }
 
@@ -305,7 +305,7 @@ main .carousel.course > div {
 }
 
 @media (min-width: 1200px) {
-  main .carousel-wrapper:has(.carousel.course > div) {
+  main .carousel-wrapper .carousel.course {
     min-height: 740px;
   }
 


### PR DESCRIPTION
This was required for WGC Dell Match play site, since there is no stats feed for that course. So it's manually authored but has a slightly different set of elements.

Test URLs:
- Before: https://main--theplayers--hlxsites.hlx.page/course
- After: https://course-carousel-flexibility--theplayers--hlxsites.hlx.page/course
- After: https://course-carousel-flexibility--theplayers--hlxsites.hlx.page/drafts/shsteimer/wgc-dell-course
