### PR TITLE
fix: proud partners styling with section metadata

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -190,6 +190,7 @@ header nav .nav-partner-appear {
 }
 
 header nav .nav-partner img {
+  height: 24px;
   max-height: 50px;
 }
 
@@ -206,6 +207,10 @@ header nav .nav-partner img {
     transform: translateX(-50%);
   }
 
+  header nav .nav-partner img {
+    height: auto;
+  }
+
   header nav[aria-expanded=false] .nav-partners {
     display: block;
     position: unset;
@@ -214,6 +219,10 @@ header nav .nav-partner img {
   header nav .nav-partners {
     width: 100%;
     background-color: transparent;
+  }
+
+  header nav .white .nav-partners {
+    color: var(--text-color);
   }
 
   header nav[aria-expanded=false] .nav-partners-title {
@@ -233,10 +242,21 @@ header nav .nav-partner img {
     background-color: var(--color-white);
   }
 
+  header nav .white .nav-partners-title::before {
+    background-color: var(--text-color);
+
+  }
+
   header nav .nav-partners-title span {
     position: relative;
     padding: 0 5px;
     background-color: var(--nav-color);
+  }
+
+  header nav .white .nav-partners-title span {
+    position: relative;
+    padding: 0 5px;
+    background-color: var(--color-white);
   }
 }
 

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -30,6 +30,7 @@ async function setupPartners(section) {
   const sponsors = pages.filter((e) => e.path.startsWith('/sponsors/'));
 
   if (sponsors.length > 0) {
+    const hasWhiteBg = [...section.classList].includes('white');
     section.classList.add('has-sponsors');
     const partners = document.createElement('div');
     partners.className = 'nav-partners';
@@ -38,7 +39,7 @@ async function setupPartners(section) {
       const partner = document.createElement('div');
       partner.className = 'nav-partner';
       if (!i) partner.classList.add('nav-partner-appear');
-      partner.append(createOptimizedPicture(sponsor.logoWhite, sponsor.title, false, [{ width: '300' }]));
+      partner.append(createOptimizedPicture(hasWhiteBg ? sponsor.image : sponsor.logoWhite, sponsor.title, false, [{ width: '300' }]));
       partners.querySelector('.nav-partner-wrapper').append(partner);
     });
     setInterval(() => {


### PR DESCRIPTION
better stying for proud partners, correct display for brand with section metadata

Test URLs:
- Before: https://main--theplayers--hlxsites.hlx.page/
- After: https://header-partners-fix--theplayers--hlxsites.hlx.page/
