### PR TITLE
fix: tee-times noon bug

### DIFF
--- a/blocks/tee-times/tee-times.js
+++ b/blocks/tee-times/tee-times.js
@@ -7,7 +7,8 @@ function convertTime(serial) {
   const seconds = totalSeconds % 60;
   totalSeconds -= seconds;
 
-  const hours = Math.floor(totalSeconds / (60 * 60));
+  let hours = Math.floor(totalSeconds / (60 * 60));
+  if (hours === 0) hours = 12;
   const minutes = (Math.floor(totalSeconds / 60) % 60).toString().padStart(2, '0');
 
   return { hours, minutes };


### PR DESCRIPTION
Test URLs:
- Before: https://main--theplayers--hlxsites.hlx.page/tee-times
- After: https://tee-times-bug--theplayers--hlxsites.hlx.page/tee-times
- Before: https://main--theplayers--hlxsites.hlx.page/
- After: https://tee-times-bug--theplayers--hlxsites.hlx.page/

tee time of noon was being misread as 0:00am