### PR TITLE
fix: if switch is missing, build in past results

### DIFF
--- a/blocks/past-results/past-results.css
+++ b/blocks/past-results/past-results.css
@@ -219,7 +219,7 @@ main .past-results .switch .switch-button {
 
 /* table */
 main .past-results table {
-  display: block;
+  min-width: 100%;
   overflow-x: scroll;
 }
 

--- a/blocks/past-results/past-results.js
+++ b/blocks/past-results/past-results.js
@@ -52,23 +52,8 @@ async function refreshResults(block, param) {
       });
     }
     // setup score switch
-    let scoreSwitch = temp.querySelector('input.switch-input');
-    if (!scoreSwitch) {
-      // build score switch
-      const controls = temp.querySelector('.controls-left');
-      const switchHTML = `<div class="controls-item">
-          <div class="switch">
-            <input class="switch-input" id="pastResultsSwitch" type="checkbox" checked="">
-            <label class="switch-title-off" for="pastResultsSwitch">To Par</label>
-            <label class="switch-button" for="pastResultsSwitch"></label>
-            <label class="switch-title-on" for="pastResultsSwitch">Total Score</label>
-          </div>
-        </div>`;
-      controls.insertAdjacentHTML('beforeend', switchHTML);
-      scoreSwitch = controls.querySelector('input.switch-input');
-    }
+    const scoreSwitch = temp.querySelector('input.switch-input');
     if (scoreSwitch && tempTable) {
-      tempTable.setAttribute('data-display-score', 'total-score');
       scoreSwitch.addEventListener('change', (e) => {
         const table = block.querySelector('table');
         if (e.target.checked) {
@@ -87,6 +72,7 @@ async function refreshResults(block, param) {
     }
     // setup table sorting
     if (tempTable) {
+      tempTable.setAttribute('data-display-score', 'total-score'); // default to total score
       tempTable.querySelectorAll('.sortable').forEach((th) => {
         const data = tempTable.querySelector('.table-data');
         const rows = [...data.querySelectorAll('tr')];
@@ -140,10 +126,10 @@ async function refreshResults(block, param) {
               return 0;
             });
           } else { // rounds
-            const currentSwitch = block.querySelector('input.switch-input').checked === true ? 'total' : 'par';
+            const currentDisplay = block.querySelector('table').getAttribute('data-display-score') === 'total-score' ? 'total' : 'par';
             rows.sort((a, b) => {
               const getVal = (el) => {
-                const text = el.querySelector(`[data-sort-${sortBy}-${currentSwitch}] > [class*=${currentSwitch}]`).textContent;
+                const text = el.querySelector(`[data-sort-${sortBy}-${currentDisplay}] > [class*=${currentDisplay}]`).textContent;
                 if (text === 'E') return 0; // e is equal to par, 0
                 return parseInt(text, 10);
               };

--- a/blocks/past-results/past-results.js
+++ b/blocks/past-results/past-results.js
@@ -52,7 +52,21 @@ async function refreshResults(block, param) {
       });
     }
     // setup score switch
-    const scoreSwitch = temp.querySelector('input.switch-input');
+    let scoreSwitch = temp.querySelector('input.switch-input');
+    if (!scoreSwitch) {
+      // build score switch
+      const controls = temp.querySelector('.controls-left');
+      const switchHTML = `<div class="controls-item">
+          <div class="switch">
+            <input class="switch-input" id="pastResultsSwitch" type="checkbox" checked="">
+            <label class="switch-title-off" for="pastResultsSwitch">To Par</label>
+            <label class="switch-button" for="pastResultsSwitch"></label>
+            <label class="switch-title-on" for="pastResultsSwitch">Total Score</label>
+          </div>
+        </div>`;
+      controls.insertAdjacentHTML('beforeend', switchHTML);
+      scoreSwitch = controls.querySelector('input.switch-input');
+    }
     if (scoreSwitch && tempTable) {
       tempTable.setAttribute('data-display-score', 'total-score');
       scoreSwitch.addEventListener('change', (e) => {


### PR DESCRIPTION
Test URLs:
- Before: https://main--theplayers--hlxsites.hlx.page/
- After: https://past-results-switch--theplayers--hlxsites.hlx.page/

~~missing switch in past results fetch causes buggy behavior, so if switch does not exist, we'll build it~~

Instead of adding a switch if there is none, I'm now just setting the default view and checking against that when sorting. 