### PR TITLE
feat: support for small images variant

### DIFF
--- a/blocks/images/images.css
+++ b/blocks/images/images.css
@@ -9,6 +9,11 @@ main .images figure figcaption {
   text-align: center;
 }
 
+main .images.small img {
+  width: 100%;
+  max-width: 330px;
+}
+
 main .images .images-columns {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
support for Images (small) block variant (capping img widths at 330px)

Test URLs:
- Before: https://main--theplayers--hlxsites.hlx.page/drafts/fkakatie/wgc-sponsors
- After: https://small-images-variant--theplayers--hlxsites.hlx.page/drafts/fkakatie/wgc-sponsors