### PR TITLE
PR template updates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,8 @@ Please always provide the [GitHub issue(s)](../issues) your PR is for, as well a
 
 Fix #<gh-issue-id>
 
+Please update the [block inventory](https://adobe.sharepoint.com/:w:/r/sites/HelixProjects/_layouts/15/Doc.aspx?sourcedoc=%7B3DCA0821-E21F-4AFE-94E6-6EA820D45D96%7D&file=block-inventory.docx&action=default&mobileredirect=true) with any relevant updates based on this PR.
+
 Test URLs:
-- Before: https://main--<repo>--<owner>.hlx.page/
-- After: https://<branch>--<repo>--<owner>.hlx.page/
+- Before: https://main--theplayers--hlxsites.hlx.page/
+- After: https://<branch>--theplayers--hlxsites.hlx.page/

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@ Please always provide the [GitHub issue(s)](../issues) your PR is for, as well a
 
 Fix #<gh-issue-id>
 
-Please update the [block inventory](https://adobe.sharepoint.com/:w:/r/sites/HelixProjects/_layouts/15/Doc.aspx?sourcedoc=%7B3DCA0821-E21F-4AFE-94E6-6EA820D45D96%7D&file=block-inventory.docx&action=default&mobileredirect=true) with any relevant updates based on this PR.
+Please update the [block inventory](https://adobe.sharepoint.com/:w:/r/sites/HelixProjects/_layouts/15/Doc.aspx?sourcedoc=%7B3DCA0821-E21F-4AFE-94E6-6EA820D45D96%7D&file=block-inventory.docx&action=default&mobileredirect=true) with any relevant block changes as a result of this PR.
 
 Test URLs:
 - Before: https://main--theplayers--hlxsites.hlx.page/


### PR DESCRIPTION
PR template updates to make it easier to setup the before/after links and a reminder to update the block inventory