### PR TITLE
fix: rolex countdown should account for tournaments more than a year in the future

### DIFF
--- a/blocks/promotion/promotion.js
+++ b/blocks/promotion/promotion.js
@@ -76,13 +76,13 @@ function getStartEndDates(countdown, spanStr) {
   if (spanStr.includes('-')) {
     const [start, end] = spanStr.split(' ').find((s) => s.includes('-')).replace(',', '').split('-');
     return {
-      start: `${parseInt(countdown.year, 10) - 1}${countdown.month}${start.padStart(2, '0')}`,
-      end: `${parseInt(countdown.year, 10) + 1}${countdown.month}${end.padStart(2, '0')}`,
+      start: `${parseInt(countdown.year, 10) - 5}${countdown.month}${start.padStart(2, '0')}`,
+      end: `${parseInt(countdown.year, 10) + 5}${countdown.month}${end.padStart(2, '0')}`,
     };
   }
   return {
-    start: `${parseInt(countdown.year, 10) - 1}${countdown.month}01`,
-    end: `${parseInt(countdown.year, 10) + 1}${countdown.month}28`,
+    start: `${parseInt(countdown.year, 10) - 5}${countdown.month}01`,
+    end: `${parseInt(countdown.year, 10) + 5}${countdown.month}28`,
   };
 }
 


### PR DESCRIPTION
presidents cup is more than a year away, which breaks the current rolex countdown config. apparently, the start and end dates don't matter (in that they can be a two-year, 20-year, 500-year gap), but 5 years seems reasonable.

Test URLs:
- Before: https://main--theplayers--hlxsites.hlx.page/
- After: https://promotion-rolex-fix--theplayers--hlxsites.hlx.page/
