### PR TITLE
fix: check for relative links in news feed

### DIFF
--- a/blocks/news/news.js
+++ b/blocks/news/news.js
@@ -20,6 +20,17 @@ async function mergeLocalNews(feed, maxItems) {
     }
     return false;
   });
+  // check feed items for relative links
+  feed.items.map((item) => {
+    const { link } = item;
+    const { host, pathname } = new URL(link);
+    if (host.includes('pgatour.com')) {
+      const splitPath = `/${pathname.split('/').slice(3).join('/')}`;
+      const match = matched.find((m) => splitPath.includes(m.path));
+      if (match) item.link = splitPath;
+    }
+    return item;
+  });
   const merged = [...feed.items, ...matched];
   const deduped = [...new Map(merged.map((m) => [
     new URL(m.link, window.location.href).pathname.split('.')[0],


### PR DESCRIPTION
checking for relative links now that some domains have moved from `pgatour.com`

Test URLs:
- Before: https://main--theplayers--hlxsites.hlx.page/
- After: https://news-relative-links--theplayers--hlxsites.hlx.page/
