### PR TITLE
Mobile safari video fix

### DIFF
--- a/blocks/player-feature/player-feature.js
+++ b/blocks/player-feature/player-feature.js
@@ -69,7 +69,16 @@ export default async function decorate(block) {
   // transform content
   const backgroundImg = transformBackgroundImage(background);
   const wrappedCredits = wrapCredits(credits);
-  if (!video) video = buildVideoContent(block.querySelector('p > em'));
+  if (!video) {
+    let videoIdElement = block.querySelector('p > em');
+    if (!videoIdElement) {
+      // some video ids look suspiciusly like phone numbers
+      // causing mobile browsers to make them into tel: links
+      // detect that case
+      videoIdElement = block.querySelector('a[href^="tel:"]');
+    }
+    video = buildVideoContent(videoIdElement);
+  }
 
   // order content
   const content = [status, name, wrappedCredits];

--- a/blocks/player-feature/player-feature.js
+++ b/blocks/player-feature/player-feature.js
@@ -70,14 +70,19 @@ export default async function decorate(block) {
   const backgroundImg = transformBackgroundImage(background);
   const wrappedCredits = wrapCredits(credits);
   if (!video) {
+    let isTelLink = false;
     let videoIdElement = block.querySelector('p > em');
     if (!videoIdElement) {
       // some video ids look suspiciusly like phone numbers
       // causing mobile browsers to make them into tel: links
       // detect that case
       videoIdElement = block.querySelector('a[href^="tel:"]');
+      isTelLink = videoIdElement !== undefined;
     }
     video = buildVideoContent(videoIdElement);
+    if (isTelLink) {
+      videoIdElement.remove();
+    }
   }
 
   // order content

--- a/blocks/player-feature/player-feature.js
+++ b/blocks/player-feature/player-feature.js
@@ -70,19 +70,15 @@ export default async function decorate(block) {
   const backgroundImg = transformBackgroundImage(background);
   const wrappedCredits = wrapCredits(credits);
   if (!video) {
-    let isTelLink = false;
     let videoIdElement = block.querySelector('p > em');
     if (!videoIdElement) {
       // some video ids look suspiciusly like phone numbers
       // causing mobile browsers to make them into tel: links
       // detect that case
       videoIdElement = block.querySelector('a[href^="tel:"]');
-      isTelLink = videoIdElement !== undefined;
     }
     video = buildVideoContent(videoIdElement);
-    if (isTelLink) {
-      videoIdElement.remove();
-    }
+    videoIdElement.remove();
   }
 
   // order content


### PR DESCRIPTION
After #65 happened to pull this up on my iPhone and noticed the video id was being transformed into a button in the button container (oddity with mobile safari turning the video id that looks like a phone number into a tel: link and then decorate buttons function merging it into the container since they are siblings). This fixes that by detecting the tel link and then killing off the element.

Test URLs:
- Before: https://main--theplayers--hlxsites.hlx.page/past-champions/archive/al-geiberger-1975
- After: https://mobile-safari-video-fix--theplayers--hlxsites.hlx.page/past-champions/archive/al-geiberger-1975
