### PR TITLE
fix: put ads block in a section container so that ad blockers don't hide the main content

### DIFF
--- a/blocks/ads/ads.js
+++ b/blocks/ads/ads.js
@@ -25,6 +25,7 @@ function debounce(func, timeout = 500) {
   };
 }
 
+
 const checkBottomAdDisplay = debounce(() => {
   const topAd = document.getElementById('pb-slot-top');
   const bottomAd = document.getElementById('sticky-anchor--wrapper');

--- a/blocks/ads/ads.js
+++ b/blocks/ads/ads.js
@@ -25,7 +25,6 @@ function debounce(func, timeout = 500) {
   };
 }
 
-
 const checkBottomAdDisplay = debounce(() => {
   const topAd = document.getElementById('pb-slot-top');
   const bottomAd = document.getElementById('sticky-anchor--wrapper');

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -747,6 +747,12 @@ document.addEventListener('click', () => sampleRUM('click'));
 
 loadPage(document);
 
+function buildAdBlock(main) {
+  const section = document.createElement('div');
+  section.append(buildBlock('ads', ''));
+  main.append(section);
+}
+
 function buildHeroBlock(main) {
   const h1 = main.querySelector('h1');
   const picture = main.querySelector('picture');
@@ -896,7 +902,7 @@ async function buildAutoBlocks(main) {
           main.append(adPlaceholder);
         }
       });
-      if (validPositions) main.append(buildBlock('ads', ''));
+      if (validPositions) buildAdBlock(main);
     }
 
     const template = getMetadata('template');


### PR DESCRIPTION
Issue was slightly different than what I said in slack...ad block was being added directly to the main element, which added a class to that 'ads-wrapper' ad block has a custom style sheet that `display: none`'s that element. This just sticks it in a section, which allows main content to be unaffected when ads are blocked. ads.css is still blocked, but that doesn't seem to actually affect anything so no need to rename the block.

Keep me honest in case putting ad into a section causes any issues, but it doesn't seem to from my testing.

Test URLs:
- Before: https://main--theplayers--hlxsites.hlx.page/military
- After: https://ad-block--theplayers--hlxsites.hlx.page/military
