### PR TITLE
fix: a better way of preserving h2 style

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -377,13 +377,13 @@ main .section.teaser p {
   text-align: center;
 }
 
-main .section.teaser .default-content-wrapper > p:first-of-type {
+main .section.teaser .default-content-wrapper > p:first-child {
   position: relative;
   font-size: var(--body-font-size-xxs);
   text-align: center;
 }
 
-main .section.teaser .default-content-wrapper > p:first-of-type em {
+main .section.teaser .default-content-wrapper > p:first-child em {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -393,8 +393,8 @@ main .section.teaser .default-content-wrapper > p:first-of-type em {
   line-height: 1;
 }
 
-main .section.teaser .default-content-wrapper > p:first-of-type em::before,
-main .section.teaser .default-content-wrapper > p:first-of-type em::after {
+main .section.teaser .default-content-wrapper > p:first-child em::before,
+main .section.teaser .default-content-wrapper > p:first-child em::after {
   content: '';
   display: block;
   top: 6px;
@@ -405,12 +405,12 @@ main .section.teaser .default-content-wrapper > p:first-of-type em::after {
 }
 
 @media (min-width: 700px) {
-  main .section.teaser .default-content-wrapper > p:first-of-type {
+  main .section.teaser .default-content-wrapper > p:first-child {
     font-size: var(--body-font-size-xs);
   }
 
-  main .section.teaser .default-content-wrapper > p:first-of-type em::before,
-  main .section.teaser .default-content-wrapper > p:first-of-type em::after {
+  main .section.teaser .default-content-wrapper > p:first-child em::before,
+  main .section.teaser .default-content-wrapper > p:first-child em::after {
     width: 70px;
   }
 }


### PR DESCRIPTION
See #68 

This is a better fix. After merging, I realized that using `:first-of-type` caused the main copy font to be smaller when there was no `<p>` before the `<h2>`, so back to using `:first-child` but making is specific to `<p>`

See  https://main--theplayers--hlxsites.hlx.page/drafts/shsteimer/charity and https://teaser-h2-fontsize--theplayers--hlxsites.hlx.page/drafts/shsteimer/charity for an example of this.

This should solve for all scenarios.

Test URLs:
- Before: https://main--theplayers--hlxsites.hlx.page/volunteer/volunteer-info/
- After: https://teaser-h2-fontsize--theplayers--hlxsites.hlx.page/volunteer/volunteer-info/
