### PR TITLE
feat(rum): track when and if Adobe Analytics tracking is executed

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -668,18 +668,18 @@ async function OptanonWrapper() {
   const OneTrustActiveGroup = () => {
     /* eslint-disable */
     var y = true, n = false;
-    var y_y_y = {'aa': y, 'aam': y, 'ecid': y};
-    var n_n_n = {'aa': n, 'aam': n, 'ecid': n};
-    var y_n_y = {'aa': y, 'aam': n, 'ecid': y};
-    var n_y_y = {'aa': n, 'aam': y, 'ecid': y};
-    
+    var y_y_y = { 'aa': y, 'aam': y, 'ecid': y };
+    var n_n_n = { 'aa': n, 'aam': n, 'ecid': n };
+    var y_n_y = { 'aa': y, 'aam': n, 'ecid': y };
+    var n_y_y = { 'aa': n, 'aam': y, 'ecid': y };
+
     if (typeof OnetrustActiveGroups != 'undefined')
       if (OnetrustActiveGroups.includes(',C0002,'))
-        return OnetrustActiveGroups.includes(',C0004,')?y_y_y:y_n_y;
+        return OnetrustActiveGroups.includes(',C0004,') ? y_y_y : y_n_y;
       else
-        return OnetrustActiveGroups.includes(',C0004,')?n_y_y:n_n_n;
-    
-    return geoInfo.country == 'US'?y_y_y:n_n_n;
+        return OnetrustActiveGroups.includes(',C0004,') ? n_y_y : n_n_n;
+
+    return geoInfo.country == 'US' ? y_y_y : n_n_n;
     /* eslint-enable */
   };
   if (!localStorage.getItem('OptIn_PreviousPermissions')) {
@@ -689,7 +689,6 @@ async function OptanonWrapper() {
   }
 
   loadScript(`https://assets.adobedtm.com/d17bac9530d5/90b3c70cfef1/launch-1ca88359b76c${isProd ? '.min' : ''}.js`);
-  sampleRUM('loadlaunch');
 }
 
 const otId = placeholders.onetrustId;

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -689,6 +689,7 @@ async function OptanonWrapper() {
   }
 
   loadScript(`https://assets.adobedtm.com/d17bac9530d5/90b3c70cfef1/launch-1ca88359b76c${isProd ? '.min' : ''}.js`);
+  sampleRUM('loadlaunch');
 }
 
 const otId = placeholders.onetrustId;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -51,8 +51,8 @@ export function sampleRUM(checkpoint, data = {}) {
             data.cwv[measurement.name] = measurement.value;
             sendPing();
           };
-            // When loading `web-vitals` using a classic script, all the public
-            // methods can be found on the `webVitals` global namespace.
+          // When loading `web-vitals` using a classic script, all the public
+          // methods can be found on the `webVitals` global namespace.
           window.webVitals.getCLS(storeCWV);
           window.webVitals.getFID(storeCWV);
           window.webVitals.getLCP(storeCWV);
@@ -632,13 +632,13 @@ export function decorateButtons(element) {
           up.classList.add('button-container');
         }
         if (up.childNodes.length === 1 && up.tagName === 'STRONG'
-            && twoup.childNodes.length === 1 && twoup.tagName === 'P') {
+          && twoup.childNodes.length === 1 && twoup.tagName === 'P') {
           a.className = 'button primary';
           twoup.classList.add('button-container');
           up.outerHTML = a.outerHTML;
         }
         if (up.childNodes.length === 1 && up.tagName === 'EM'
-            && twoup.childNodes.length === 1 && twoup.tagName === 'P') {
+          && twoup.childNodes.length === 1 && twoup.tagName === 'P') {
           a.className = 'button secondary';
           twoup.classList.add('button-container');
           up.outerHTML = a.outerHTML;
@@ -738,7 +738,7 @@ initHlx();
  */
 
 const LCP_BLOCKS = ['carousel', 'hero']; // add your LCP blocks to the list
-const RUM_GENERATION = 'project-1'; // add your RUM generation information here
+const RUM_GENERATION = 'intercept-aa-2'; // add your RUM generation information here
 const PRODUCTION_DOMAINS = ['www.theplayers.com'];
 
 sampleRUM('top');
@@ -1051,4 +1051,26 @@ export function addHeaderSizing(block, classPrefix = 'heading', selector = 'h1, 
       if (length >= size.threshold) h.classList.add(`${classPrefix}-${size.name}`);
     });
   });
+}
+
+
+try {
+  Object.defineProperty(window, 's', {
+    set(x) {
+      this._hlx_s = x;
+      const handler = {
+        get(_, prop) {
+          if (prop === 't') {
+            sampleRUM('adobe-analytics');
+          }
+          return Reflect.get(...arguments);
+        }
+      };
+      this._hlx_s_proxy = new Proxy(this._hlx_s, handler);
+    },
+    get(x) {
+      return this._hlx_s_proxy;
+    }
+  });
+} catch (e) {
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1053,24 +1053,24 @@ export function addHeaderSizing(block, classPrefix = 'heading', selector = 'h1, 
   });
 }
 
-
 try {
+  const hidden = Symbol('hidden');
+  const proxy = Symbol('proxy');
   Object.defineProperty(window, 's', {
     set(x) {
-      this._hlx_s = x;
+      this[hidden] = x;
       const handler = {
-        get(_, prop) {
+        get(target, prop, receiver) {
           if (prop === 't') {
             sampleRUM('adobe-analytics');
           }
-          return Reflect.get(...arguments);
-        }
+          return Reflect.get(target, prop, receiver);
+        },
       };
-      this._hlx_s_proxy = new Proxy(this._hlx_s, handler);
+      this[proxy] = new Proxy(this[hidden], handler);
     },
-    get(x) {
-      return this._hlx_s_proxy;
-    }
+    get() {
+      return this[proxy];
+    },
   });
-} catch (e) {
-}
+} catch (e) { /* ignore */ }


### PR DESCRIPTION
~~this will allow you to determine which percentage of visitors get the Adobe Launch script~~

The goal is to be able to track if Adobe Analytics is tracking the page view, so we intercept the creation of the `window.s` variable, and install a proxy that traps the `s.t()` function call. https://experienceleague.adobe.com/docs/analytics/implementation/js/overview.html?lang=en

- After: https://launch-rum--theplayers--hlxsites.hlx.page/?rum=on
