### PR TITLE
fix: remove webview param from article links. use video shareUrl now that it works

### DIFF
--- a/blocks/news/news.js
+++ b/blocks/news/news.js
@@ -86,7 +86,8 @@ async function getVideos(limit, placeholders) {
       pubdate
       category
       id
-      duration 
+      duration
+      shareUrl
     }
   }`, {
     tour: placeholders.tourCode.toUpperCase(),
@@ -97,7 +98,7 @@ async function getVideos(limit, placeholders) {
     const json = await resp.json();
     if (json.data && json.data.videos) {
       const videoItems = json.data.videos.map((video) => ({
-        url: `https://www.pgatour.com/video/${video.category}/${video.id}`,
+        url: video.shareUrl,
         type: 'video',
         // eslint-disable-next-line no-template-curly-in-string
         image: video.poster.replace('${height}', '311').replace('${width}', '425'),
@@ -132,13 +133,18 @@ async function getArticles(limit, placeholders) {
     if (resp.ok) {
       const json = await resp.json();
       if (json.data && json.data.newsArticles && json.data.newsArticles.articles) {
-        const articles = json.data.newsArticles.articles.map((article) => ({
-          url: article.url,
-          type: 'article',
-          image: article.articleImage,
-          title: article.teaserHeadline,
-          date: article.updateDate,
-        }));
+        const articles = json.data.newsArticles.articles.map((article) => {
+          const articleUrl = new URL(article.url);
+          articleUrl.searchParams.delete('webview');
+          const articleData = {
+            url: articleUrl.toString(),
+            type: 'article',
+            image: article.articleImage,
+            title: article.teaserHeadline,
+            date: article.updateDate,
+          };
+          return articleData;
+        });
         return articles;
       }
     }

--- a/blocks/related-stories/related-stories.js
+++ b/blocks/related-stories/related-stories.js
@@ -30,15 +30,19 @@ async function getArticles(limit, placeholders) {
     if (resp.ok) {
       const json = await resp.json();
       if (json.data && json.data.newsArticles && json.data.newsArticles.articles) {
-        const articles = json.data.newsArticles.articles.map((article) => ({
-          url: article.url,
-          type: 'article',
-          image: article.articleImage,
-          title: article.teaserHeadline,
-          date: article.updateDate,
-          franchise: article.franchise,
-          franchiseDisplayName: article.franchiseDisplayName,
-        }));
+        const articles = json.data.newsArticles.articles.map((article) => {
+          const articleUrl = new URL(article.url);
+          articleUrl.searchParams.delete('webview');
+          return {
+            url: articleUrl.toString(),
+            type: 'article',
+            image: article.articleImage,
+            title: article.teaserHeadline,
+            date: article.updateDate,
+            franchise: article.franchise,
+            franchiseDisplayName: article.franchiseDisplayName,
+          };
+        });
         return articles;
       }
     }


### PR DESCRIPTION
adjustment for news articles now that feeds are live.

Test URLs:
- Before: https://main--theplayers--hlxsites.hlx.page/
- Before: https://main--theplayers--hlxsites.hlx.page/news/2023/03/06/driving-dialogue-for-mental-health
- After: https://news-fix--theplayers--hlxsites.hlx.page/
- After: https://news-fix--theplayers--hlxsites.hlx.page/news/2023/03/06/driving-dialogue-for-mental-health
