### PR TITLE
chore: move path for sponsors nav content to a placeholder

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -26,45 +26,47 @@ function displayNextPartner(proud) {
   partners[(appeared + 1) % partners.length].classList.add('nav-partner-appear');
 }
 
-async function setupPartners(section) {
+async function setupPartners(section, ph) {
   let sponsors = [];
-  try {
-    // const resp = await fetch('/drafts/shsteimer/sponsors');
-    const resp = await fetch('/sponsors');
-    // eslint-disable-next-line no-await-in-loop
-    const html = await resp.text();
-    const dp = new DOMParser();
-    const sponsorsDoc = dp.parseFromString(html, 'text/html');
-    if (sponsorsDoc.querySelector('.sponsors.v2')) {
-      const sponsorRows = [...sponsorsDoc.querySelector('.sponsors.v2').children];
-      sponsors = await setupSponsorsV2(sponsorRows);
-    } else {
-      // backwards compat, kill off after marge and content update
-      const sponsorLinks = [...sponsorsDoc.querySelectorAll('.sponsors a')].map((a) => a.href);
-      sponsors = await setupSponsors(sponsorLinks);
+  const sponsorsNavPath = ph.sponsorsNav;
+  if (sponsorsNavPath) {
+    try {
+      const resp = await fetch(sponsorsNavPath);
+      // eslint-disable-next-line no-await-in-loop
+      const html = await resp.text();
+      const dp = new DOMParser();
+      const sponsorsDoc = dp.parseFromString(html, 'text/html');
+      if (sponsorsDoc.querySelector('.sponsors.v2')) {
+        const sponsorRows = [...sponsorsDoc.querySelector('.sponsors.v2').children];
+        sponsors = await setupSponsorsV2(sponsorRows);
+      } else {
+        // backwards compat, kill off after marge and content update
+        const sponsorLinks = [...sponsorsDoc.querySelectorAll('.sponsors a')].map((a) => a.href);
+        sponsors = await setupSponsors(sponsorLinks);
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.log(err);
     }
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.log(err);
-  }
 
-  if (sponsors.length > 0) {
-    const hasWhiteBg = [...section.classList].includes('white');
-    section.classList.add('has-sponsors');
-    const partners = document.createElement('div');
-    partners.className = 'nav-partners';
-    partners.innerHTML = '<div class="nav-partners-title"><span>Proud Partners</span></div><div class="nav-partner-wrapper"></div>';
-    sponsors.forEach((sponsor, i) => {
-      const partner = document.createElement('div');
-      partner.className = 'nav-partner';
-      if (!i) partner.classList.add('nav-partner-appear');
-      partner.append(createOptimizedPicture(hasWhiteBg ? sponsor.image : sponsor.logoWhite, sponsor.title, false, [{ width: '300' }]));
-      partners.querySelector('.nav-partner-wrapper').append(partner);
-    });
-    setInterval(() => {
-      displayNextPartner(partners);
-    }, 5000);
-    section.append(partners);
+    if (sponsors.length > 0) {
+      const hasWhiteBg = [...section.classList].includes('white');
+      section.classList.add('has-sponsors');
+      const partners = document.createElement('div');
+      partners.className = 'nav-partners';
+      partners.innerHTML = '<div class="nav-partners-title"><span>Proud Partners</span></div><div class="nav-partner-wrapper"></div>';
+      sponsors.forEach((sponsor, i) => {
+        const partner = document.createElement('div');
+        partner.className = 'nav-partner';
+        if (!i) partner.classList.add('nav-partner-appear');
+        partner.append(createOptimizedPicture(hasWhiteBg ? sponsor.image : sponsor.logoWhite, sponsor.title, false, [{ width: '300' }]));
+        partners.querySelector('.nav-partner-wrapper').append(partner);
+      });
+      setInterval(() => {
+        displayNextPartner(partners);
+      }, 5000);
+      section.append(partners);
+    }
   }
 }
 
@@ -242,25 +244,27 @@ export default async function decorate(block) {
           </p>`;
         data.append(weather);
       }
+
+      if (data.hasChildNodes()) statusBar.append(data);
+
+      const brand = nav.querySelector('.nav-brand');
+      const sectionMeta = brand.querySelector('.section-metadata');
+      if (sectionMeta) {
+        const meta = readBlockConfig(sectionMeta);
+
+        if (meta.background) {
+          brand.classList.add(meta.background);
+        }
+
+        sectionMeta.remove();
+      }
+
+      await setupPartners(brand, placeholders);
     } catch (error) {
       // eslint-disable-next-line no-console
       console.log('failed to load placeholders', error);
     }
-    if (data.hasChildNodes()) statusBar.append(data);
 
-    const brand = nav.querySelector('.nav-brand');
-    const sectionMeta = brand.querySelector('.section-metadata');
-    if (sectionMeta) {
-      const meta = readBlockConfig(sectionMeta);
-
-      if (meta.background) {
-        brand.classList.add(meta.background);
-      }
-
-      sectionMeta.remove();
-    }
-
-    await setupPartners(brand);
     block.classList.add('appear');
   }
 }


### PR DESCRIPTION
two reasons for this:
1 for sites with no sponsors nav, we won't set the value, saving on an http request that will 404
2. for pres cup, the sponsors page has no sponsors block, so need the nav content in a separate fragment

Test URLs:
- Before: https://main--theplayers--hlxsites.hlx.page/sponsors
- Before: https://main--theplayers--hlxsites.hlx.page/
- After: https://sponsors-ph--theplayers--hlxsites.hlx.page/
- After: https://sponsors-ph--theplayers--hlxsites.hlx.page/sponsors
